### PR TITLE
Improve internal links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# Link Preview
+# [Link Preview](https://github.com/datlechin/flarum-link-preview)
 
 ![License](https://img.shields.io/badge/license-MIT-blue.svg) [![Latest Stable Version](https://img.shields.io/packagist/v/datlechin/flarum-link-preview.svg)](https://packagist.org/packages/datlechin/flarum-link-preview) [![Total Downloads](https://img.shields.io/packagist/dt/datlechin/flarum-link-preview.svg)](https://packagist.org/packages/datlechin/flarum-link-preview)
 
-A [Flarum](http://flarum.org) extension. Automatically display a rich preview of the link contents, such as title, description and image.
+A [Flarum](https://github.com/flarum) extension. Automatically display a rich preview of the link contents, such as title, description and image.
 
-This extension uses Google Favicon to get website favicon and [PHPScraper](https://phpscraper.de) to get website information like title, description, ...
+This extension uses Google Favicon to get website favicon and [PHPScraper](https://github.com/spekulatius/PHPScraper) to get website information like title, description, ...
 
 ![](https://user-images.githubusercontent.com/56961917/190849018-4ffdfd1f-33a0-4b09-8df8-2c08a85aebe6.png)
 


### PR DESCRIPTION
Hey @datlechin 

Do you think we could merge these adjustment to the links? Github-internal links help to rank better on Google than external nofollow-links. This improves your ranking, flarum's and PHP Scraper's ranking altogether.

Cheers,
Peter