### PR TITLE
fix: return user-friendly error messages instead of raw exceptions

### DIFF
--- a/src/Api/Controllers/BatchLinkPreviewController.php
+++ b/src/Api/Controllers/BatchLinkPreviewController.php
@@ -3,6 +3,7 @@
 namespace Datlechin\LinkPreview\Api\Controllers;
 
 use Datlechin\LinkPreview\Services\LinkPreviewService;
+use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Promise\Utils;
 use Laminas\Diactoros\Response\JsonResponse;
 use Psr\Http\Message\ResponseInterface as Response;
@@ -22,9 +23,9 @@ class BatchLinkPreviewController implements RequestHandlerInterface
 
             return new JsonResponse($result);
         } catch (Throwable $e) {
-            return new JsonResponse([
-                'error' => $e->getMessage(),
-            ]);
+            return new JsonResponse(
+                $this->service->getErrorResponse('datlechin-link-preview.forum.site_cannot_be_reached'),
+            );
         }
     }
 
@@ -94,9 +95,7 @@ class BatchLinkPreviewController implements RequestHandlerInterface
                 $promises[$originalUrl] = $this->service->getClient()->getAsync($originalUrl);
                 $normalizedUrls[$originalUrl] = $normalizedUrl;
             } catch (Throwable $e) {
-                $results[$originalUrl] = [
-                    'error' => 'Failed to create request: ' . $e->getMessage(),
-                ];
+                $results[$originalUrl] = $this->service->getErrorResponse('datlechin-link-preview.forum.site_cannot_be_reached');
             }
         }
 
@@ -111,11 +110,7 @@ class BatchLinkPreviewController implements RequestHandlerInterface
                 $response = $responses[$originalUrl] ?? null;
 
                 if (!$response || $response['state'] !== 'fulfilled') {
-                    $results[$originalUrl] = [
-                        'error' => $response['reason'] instanceof \Exception ?
-                            $response['reason']->getMessage() :
-                            'Failed to fetch preview',
-                    ];
+                    $results[$originalUrl] = $this->service->getErrorResponse('datlechin-link-preview.forum.site_cannot_be_reached');
                     continue;
                 }
 
@@ -128,9 +123,7 @@ class BatchLinkPreviewController implements RequestHandlerInterface
 
                 $results[$originalUrl] = $data;
             } catch (Throwable $e) {
-                $results[$originalUrl] = [
-                    'error' => $e->getMessage(),
-                ];
+                $results[$originalUrl] = $this->service->getErrorResponse('datlechin-link-preview.forum.site_cannot_be_reached');
             }
         }
 

--- a/src/Api/Controllers/SingleLinkPreviewController.php
+++ b/src/Api/Controllers/SingleLinkPreviewController.php
@@ -3,6 +3,7 @@
 namespace Datlechin\LinkPreview\Api\Controllers;
 
 use Datlechin\LinkPreview\Services\LinkPreviewService;
+use GuzzleHttp\Exception\RequestException;
 use Laminas\Diactoros\Response\JsonResponse;
 use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;
@@ -44,10 +45,14 @@ class SingleLinkPreviewController implements RequestHandlerInterface
             $this->service->cacheData($normalizedUrl, $data);
 
             return new JsonResponse($data);
+        } catch (RequestException $e) {
+            return new JsonResponse(
+                $this->service->getErrorResponse('datlechin-link-preview.forum.site_cannot_be_reached'),
+            );
         } catch (Throwable $e) {
-            return new JsonResponse([
-                'error' => $e->getMessage(),
-            ]);
+            return new JsonResponse(
+                $this->service->getErrorResponse('datlechin-link-preview.forum.site_cannot_be_reached'),
+            );
         }
     }
 }

--- a/src/Services/LinkPreviewService.php
+++ b/src/Services/LinkPreviewService.php
@@ -44,9 +44,30 @@ class LinkPreviewService
     protected function setupHttpClient(): void
     {
         $this->httpClient = new Client([
-            'timeout' => 5,
-            'connect_timeout' => 5,
+            'timeout' => 15,
+            'connect_timeout' => 10,
             'verify' => false,
+            'allow_redirects' => [
+                'max' => 10,
+                'strict' => false,
+                'referer' => true,
+                'track_redirects' => true,
+            ],
+            'headers' => [
+                'User-Agent' => 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
+                'Accept' => 'text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7',
+                'Accept-Language' => 'en-US,en;q=0.9',
+                'Accept-Encoding' => 'gzip, deflate, br',
+                'DNT' => '1',
+                'Connection' => 'keep-alive',
+                'Upgrade-Insecure-Requests' => '1',
+                'Sec-Fetch-Dest' => 'document',
+                'Sec-Fetch-Mode' => 'navigate',
+                'Sec-Fetch-Site' => 'none',
+                'Sec-Fetch-User' => '?1',
+                'Cache-Control' => 'max-age=0',
+            ],
+            'cookies' => true,
         ]);
     }
 


### PR DESCRIPTION
Fix for v1.6.0 issue where HTTP errors exposed raw Guzzle exception messages with HTML content. Now returns translated site_cannot_be_reached message instead.